### PR TITLE
Additivity of two MongoDBObjects

### DIFF
--- a/casbah-commons/src/main/scala/MongoDBObject.scala
+++ b/casbah-commons/src/main/scala/MongoDBObject.scala
@@ -89,6 +89,10 @@ trait MongoDBObject extends Map[String, AnyRef] {
     this ++ b.result
   }
 
+  def ++(other: DBObject): DBObject = {
+    super.++(other)
+  }
+
   /** Lazy utility method to allow typing without conflicting with Map's required get() method and causing ambiguity */
   def getAs[A <: Any : Manifest](key: String): Option[A] = {
     require(manifest[A] != manifest[scala.Nothing], 

--- a/casbah-commons/src/test/scala/MongoDBObjectSpec.scala
+++ b/casbah-commons/src/test/scala/MongoDBObjectSpec.scala
@@ -146,8 +146,7 @@ class MongoDBObjectSpec extends Specification with PendingUntilFixed {
         newObj must beEqualTo(MongoDBObject("x" -> "y", "a" -> "b", "foo" -> "bar"))
       }
       "A list of Tuple pairs with ++ " in {
-        // Note - you currently have to explicitly cast this or get back a map. ugh.
-        val newObj: DBObject = MongoDBObject("x" -> "y", "a" -> "b") ++ ("foo" -> "bar", "n" -> 5)
+        val newObj = MongoDBObject("x" -> "y", "a" -> "b") ++ ("foo" -> "bar", "n" -> 5)
         newObj must notBeNull
         newObj must haveSuperClass[DBObject]
 
@@ -181,6 +180,15 @@ class MongoDBObjectSpec extends Specification with PendingUntilFixed {
         dbObj must beEqualTo(MongoDBObject("x" -> "y", "a" -> "b", "foo" -> "bar", "n" -> 5, "fbc" -> 542542.2))
 
       }
+    }
+
+    "Support additivity with another MongoDBObject" in {
+      val newObj = MongoDBObject("x" -> "y", "a" -> "b") ++ MongoDBObject("foo" -> "bar", "n" -> 5)
+
+      newObj must notBeNull
+      newObj must haveSuperClass[DBObject]
+
+      newObj must beEqualTo(MongoDBObject("x" -> "y", "a" -> "b", "foo" -> "bar", "n" -> 5))
     }
 
     "Support the as[<type>] method" in {


### PR DESCRIPTION
Currently MongoDBObject() ++ MongoDBObject() == Map[String,Any]() which came as a bit of a surprise to me.  This appears to fix that behaviour without breaking anything else.
