### PR TITLE
as not behaving as intended

### DIFF
--- a/casbah-commons/src/main/scala/MongoDBObject.scala
+++ b/casbah-commons/src/main/scala/MongoDBObject.scala
@@ -67,13 +67,13 @@ trait MongoDBObject extends Map[String, AnyRef] {
    * @return (A)
    * @throws NoSuchElementException
    */
-  def as[A <: Any : Manifest](key: String) = {
+  def as[A <: Any : Manifest](key: String): A = {
     require(manifest[A] != manifest[scala.Nothing], 
             "Type inference failed; as[A]() requires an explicit type argument" + 
             "(e.g. dbObject.as[<ReturnType>](\"someKey\") ) to function correctly.")
 
     underlying.get(key) match {
-      case null => default(key)
+      case null => default(key).asInstanceOf[A]
       case value => value.asInstanceOf[A]
     }
   }

--- a/casbah-commons/src/test/scala/MongoDBObjectSpec.scala
+++ b/casbah-commons/src/test/scala/MongoDBObjectSpec.scala
@@ -194,14 +194,14 @@ class MongoDBObjectSpec extends Specification with PendingUntilFixed {
     "Support the as[<type>] method" in {
       val dbObj = MongoDBObject("x" -> 5.2, 
                                 "y" -> 9, 
-                                "foo" -> ("a", "b", "c"), 
+                                "foo" -> MongoDBList("a", "b", "c"),
                                 "bar" -> MongoDBObject("baz" -> "foo"))
       dbObj must notBeNull
       dbObj must haveSuperClass[DBObject]
 
       dbObj.as[Double]("x") must notBeNull
       dbObj.as[Int]("y") must notBeNull
-      dbObj.as[Seq[_]]("foo") must notBeNull
+      dbObj.as[BasicDBList]("foo") must notBeNull
       dbObj.as[DBObject]("bar") must notBeNull
       dbObj.as[String]("nullValue") must throwA[NoSuchElementException]
     }
@@ -223,8 +223,12 @@ class MongoDBObjectSpec extends Specification with PendingUntilFixed {
           dbObj.as[Double]("y") must haveClass[java.lang.Double]
           dbObj.as[DBObject]("embedded") must haveSuperClass[DBObject]
           dbObj.as[Float]("omgponies") must throwA[NoSuchElementException] 
-          dbObj.as[Double]("x") /*must throwA[ClassCastException]*/
+          dbObj.as[Double]("x") must throwA[ClassCastException]
 
+          "the result should be assignable to the type specified" in {
+            val y: Double = dbObj.as[Double]("y")
+            y must notBeNull
+          }
         }
     }
   }


### PR DESCRIPTION
Hi Brendan,

One of my colleagues noticed that the existing behaviour of "as" on MongoDBObject wasn't much help, as you still got Any.  I think the approach in this patch is reasonable, since if you are brave enough to implement your own default for a non-homogeneous Map, then it should return the right type for the right key.

Phil
