### PR TITLE
List argument to MongoDBObject

### DIFF
--- a/casbah-commons/src/main/scala/MongoDBObject.scala
+++ b/casbah-commons/src/main/scala/MongoDBObject.scala
@@ -173,6 +173,7 @@ object MongoDBObject {
   def empty: DBObject = new MongoDBObject { val underlying = new BasicDBObject }
 
   def apply[A <: String, B <: Any](elems: (A, B)*): DBObject = (newBuilder[A, B] ++= elems).result
+  def apply[A <: String, B <: Any](elems: List[(A, B)]): DBObject = apply(elems: _*)
 
   def newBuilder[A <: String, B <: Any]: MongoDBObjectBuilder = new MongoDBObjectBuilder
 

--- a/casbah-commons/src/test/scala/MongoDBObjectSpec.scala
+++ b/casbah-commons/src/test/scala/MongoDBObjectSpec.scala
@@ -84,6 +84,20 @@ class MongoDBObjectSpec extends Specification with PendingUntilFixed {
       dbObj must haveSize(0)
     }
 
+    "allow list as well as varargs construction" in {
+      val dbObj = MongoDBObject(List("x" -> 1, "y" -> 2))
+
+      // A Java version to compare with
+      val jBldr = new com.mongodb.BasicDBObjectBuilder
+      jBldr.add("x", 1)
+      jBldr.add("y", 2)
+      val jObj = jBldr.get
+
+      dbObj must haveSuperClass[DBObject]
+      jObj must haveSuperClass[DBObject]
+      dbObj must beEqualTo(jObj)
+    }
+
     "support a 2.8 factory interface which returns a DBObject" in {
       val dbObj = MongoDBObject("x" -> 5, "y" -> 212.8, "spam" -> "eggs",
         "embedded" -> MongoDBObject("foo" -> "bar"))


### PR DESCRIPTION
The :_\* syntax is irregular and ugly enough that I'd rather have it in library code where possible.
