### PR TITLE
add socketKeepAlive option

### DIFF
--- a/casbah-core/src/main/scala/MongoOptions.scala
+++ b/casbah-core/src/main/scala/MongoOptions.scala
@@ -53,7 +53,8 @@ object MongoOptions {
     threadsAllowedToBlockForConnectionMultiplier: Int = new MongoOptions().threadsAllowedToBlockForConnectionMultiplier,
     maxWaitTime: Int = new MongoOptions().maxWaitTime,
     connectTimeout: Int = new MongoOptions().connectTimeout,
-    socketTimeout: Int = new MongoOptions().socketTimeout) = {
+    socketTimeout: Int = new MongoOptions().socketTimeout,
+    socketKeepAlive: Int = new MongoOptions().socketKeepAlive) = {
     val options = new MongoOptions;
 
     options.autoConnectRetry = autoConnectRetry
@@ -62,6 +63,7 @@ object MongoOptions {
     options.maxWaitTime = maxWaitTime
     options.connectTimeout = connectTimeout
     options.socketTimeout = socketTimeout
+    options.socketKeepAlive = socketKeepAlive
     options
   }
 


### PR DESCRIPTION
from mongo-java-driver version 2.5.3, 'socketKeepAlive' was added into MongoOptions.
Casbah should support this option.
