### PR TITLE
Use DBObject as type for jsScope in MapReduceCommand

### DIFF
--- a/casbah-core/src/main/scala/MongoCollection.scala
+++ b/casbah-core/src/main/scala/MongoCollection.scala
@@ -506,7 +506,7 @@ abstract class MongoCollection extends Logging with Iterable[DBObject] {
     sort: Option[DBObject] = None,
     limit: Option[Int] = None,
     finalizeFunction: Option[JSFunction] = None,
-    jsScope: Option[String] = None,
+    jsScope: Option[DBObject] = None,
     verbose: Boolean = false): map_reduce.MapReduceResult =
     map_reduce.MapReduceResult(getDB.command(MapReduceCommand(name, mapFunction, reduceFunction,
       output, query, sort, limit, finalizeFunction,

--- a/casbah-core/src/main/scala/map_reduce/MapReduceCommand.scala
+++ b/casbah-core/src/main/scala/map_reduce/MapReduceCommand.scala
@@ -49,7 +49,7 @@ object MapReduceCommand {
     sort: Option[DBObject] = None,
     limit: Option[Int] = None,
     finalizeFunction: Option[JSFunction] = None,
-    jsScope: Option[String] = None,
+    jsScope: Option[DBObject] = None,
     verbose: Boolean = false) = {
     val mrc = new MapReduceCommand()
     mrc.input = input
@@ -89,7 +89,7 @@ class MapReduceCommand protected[mongodb] () {
   var sort: Option[DBObject] = None
   var limit: Option[Int] = None
   var finalizeFunction: Option[JSFunction] = None
-  var jsScope: Option[String] = None
+  var jsScope: Option[DBObject] = None
 
   def toDBObject = {
     val dataObj = MongoDBObject.newBuilder

--- a/casbah-core/src/test/scala/MapReduceSpec.scala
+++ b/casbah-core/src/test/scala/MapReduceSpec.scala
@@ -120,6 +120,36 @@ class MapReduceSpec extends CasbahSpecification {
       item must beEqualTo(MongoDBObject("_id" -> 90.0, "value" -> 8.552400000000002))
     }
 
+    "Produce results with variable from jsScope" in {
+      val f = """
+        function f( year, value ){
+          value.scopeVar = scopeVar;
+          return scopeVar;
+        }
+      """
+
+      val coll = mongoDB("yield_historical.in")
+      val result = coll.mapReduce(
+        mapJS,
+        reduceJS,
+        MapReduceInlineOutput,
+        finalizeFunction = Some(f),
+        jsScope = Some(MongoDBObject("scopeVar" -> "testScopeVar")),
+        verbose = true)
+
+      /*log.warn("M/R Result: %s", result)*/
+
+
+      result.isError must beFalse
+      result.raw.getAs[String]("result") must beNone
+      result.size must beGreaterThan(0)
+      result.size must beEqualTo(result.raw.expand[Int]("counts.output").getOrElse(-1))
+
+      val item = result.next
+      item must beDBObject
+      item must beEqualTo(MongoDBObject("_id" -> 90.0, "value" -> "testScopeVar"))
+    }
+
     "Produce results for merged output" in {
       verifyAndInitTreasuryData
 


### PR DESCRIPTION
Hi,

I don't know if it's ok for backward compatibility but I find it more convenient to use `DBObject` for `jsScope` type as it should be an Object with each field added to the global scope.

Moreover when using `String`, it just does not work when setting the `jsScope` with:

```
...
jsScope = Some("{ testVar: true }")
...
```

When looking at the mongo logs, it produces the following:

```
scope: "{ testVar: true }"
```

instead of

```
scope: { testVar: true }
```

I've added a test to the MapReduceSpec.

Maybe it's better to try fixing the `jsScope` as `String` instead of using `DBObject`.

WDYT?
