### PR TITLE
OpLog can use replica sets

### DIFF
--- a/casbah-core/src/main/scala/util/OpLog.scala
+++ b/casbah-core/src/main/scala/util/OpLog.scala
@@ -30,12 +30,13 @@ import scala.util.control.Exception._
 
 class MongoOpLog(mongo: MongoConnection = MongoConnection(),
   startTimestamp: Option[BSONTimestamp] = None,
-  namespace: Option[String] = None) extends Iterator[MongoOpLogEntry] with Logging {
+  namespace: Option[String] = None,
+  masterSlaveReplication: Boolean = true) extends Iterator[MongoOpLogEntry] with Logging {
 
   implicit object BSONTimestampOk extends ValidDateOrNumericType[org.bson.types.BSONTimestamp]
 
   protected val local = mongo("local")
-  protected val oplog = local("oplog.$main")
+  protected val oplog = local("oplog." if masterSlaveReplication "$main" else "rs")
 
   val tsp = verifyOpLog
 


### PR DESCRIPTION
Still defaults to 'oplog.$main' for the OpLog collection name, but can be 'oplog.rs' if masterSlaveReplication is false
See docs at http://www.mongodb.org/display/DOCS/Replication+Oplog+Length

cc/ @dvingo, @yegeniy, @matthewfitz
