### PR TITLE
Update casbah-commons/src/main/scala/MongoDBList.scala

### DIFF
--- a/casbah-commons/src/main/scala/MongoDBList.scala
+++ b/casbah-commons/src/main/scala/MongoDBList.scala
@@ -44,7 +44,7 @@ class MongoDBList(val underlying: BasicDBList = new BasicDBList) extends Seq[Any
     this
   }
 
-  def insertAll(i: Int, elems: Traversable[Any]) = {
+  def insertAll(i: Int, elems: scala.collection.Traversable[Any]) = {
     val ins = underlying.subList(0, i)
     elems.foreach(x => ins.add(x.asInstanceOf[AnyRef]))
   }


### PR DESCRIPTION
The MongoDBList.concat(..) function, seems to force the use of a mutable Traversable object, due to the
'import scala.collection.mutable._' statement on line 27. 

This function should accept a scala.collection.Traversable. 
