### PR TITLE
Register the core Serialization helpers only once

### DIFF
--- a/casbah-commons/src/main/scala/Implicits.scala
+++ b/casbah-commons/src/main/scala/Implicits.scala
@@ -62,8 +62,12 @@ trait Implicits {
 
   implicit def unwrapDBList(in: MongoDBList): BasicDBList = in.underlying
 
-  // Register the core Serialization helpers.
-  conversions.scala.RegisterConversionHelpers()
+  // Ensure that the core Serialization helpers are registered.
+  EnsureConversionHelpersRegistration.ensure
+}
+
+object EnsureConversionHelpersRegistration {
+  lazy val ensure = conversions.scala.RegisterConversionHelpers()
 }
 
 object Implicits extends Implicits


### PR DESCRIPTION
If the trait Implicits is used with short lived objects the overhead of re-registering the helpers becomes quite large.
