### PR TITLE
Add  $max operation

### DIFF
--- a/casbah-core/src/test/scala/QueryIntegrationSpec.scala
+++ b/casbah-core/src/test/scala/QueryIntegrationSpec.scala
@@ -151,6 +151,27 @@ class QueryIntegrationSpec extends CasbahDBTestSpecification {
     }
   }
 
+  "$max" should {
+    "Work with a single pair" in {
+      collection.drop()
+      collection += MongoDBObject("hello" -> "world", "foo" -> 5.0)
+
+      collection.update(MongoDBObject("hello" -> "world"), $max("foo" -> 6.0))
+      collection.findOne().get("foo") must beEqualTo(6)
+    }
+    "Work with multiple pairs" in {
+      collection.drop()
+      collection += MongoDBObject("hello" -> "world", "foo" -> 5.0, "bar" -> 5.0)
+
+      val max = $max("foo" -> 3.0, "bar" -> 10.0)
+      collection.update(MongoDBObject("hello" -> "world"), max)
+
+      val doc = collection.findOne()
+      doc.get("foo") must beEqualTo(5)
+      doc.get("bar") must beEqualTo(10)
+    }
+  }
+
   "$or" should {
     "load some test data first" in {
       collection.drop()

--- a/casbah-query/src/main/scala/BarewordOperators.scala
+++ b/casbah-query/src/main/scala/BarewordOperators.scala
@@ -82,6 +82,7 @@ trait FluidQueryBarewordOps extends SetOp
 with SetOnInsertOp
 with UnsetOp
 with IncOp
+with MaxOp
 with OrOp
 with AndOp
 with RenameOp
@@ -157,6 +158,26 @@ trait UnsetOp extends BarewordQueryOperator {
  */
 trait IncOp extends BarewordQueryOperator {
   def $inc[T: ValidNumericType](args: (String, T)*): DBObject = apply[T]("$inc")(args)
+}
+
+/**
+ * Trait to provide the \$max (max) method as a bareword operator..
+ *
+ * {{{ \$max ("foo" -> 10) }}}
+ *
+ * Targets an RValue of (String, ValidNumericType)* to be converted to a DBObject
+ *
+ * Due to a quirk in the way I implemented type detection this fails if you mix ValidNumericType types.
+ * E.g. floats work, but not mixing floats and ints. This can be easily circumvented
+ * if you want 'ints' with floats by making your ints floats with .0:
+ *
+ * {{{ \$max ("foo" -> 5.0, "bar" -> 1.6) }}}
+ *
+ * @since 2.7
+ * @see http://docs.mongodb.org/manual/reference/operator/update/max/
+ */
+trait MaxOp extends BarewordQueryOperator {
+  def $max[T: ValidNumericType](args: (String, T)*): DBObject = apply[T]("$max")(args)
 }
 
 /*

--- a/casbah-query/src/test/scala/BarewordOperatorsSpec.scala
+++ b/casbah-query/src/test/scala/BarewordOperatorsSpec.scala
@@ -91,6 +91,20 @@ class BarewordOperatorsSpec extends CasbahMutableSpecification {
     }
   }
 
+  "Casbah's DSL $max Operator" should {
+    "Accept one or many sets of values" in {
+      "A single set" in {
+        val max = $max("foo" -> 5.0)
+        max must haveEntry("$max.foo" -> 5.0)
+      }
+      "Multiple sets" in {
+        val max = $max("foo" -> 5.0, "bar" -> -1.2)
+        max must haveEntry("$max.foo" -> 5.0)
+        max must haveEntry("$max.bar" -> -1.2)
+      }
+    }
+  }
+
   "Casbah's DSL $or Operator" should {
     "Accept multiple values" in {
       val or = $or("foo" -> "bar", "x" -> "y")


### PR DESCRIPTION
Add $max operator to casbah.

The $max operator updates the value of the field to a specified value if the specified value is greater than the current value of the field. If the field does not exists, the $max operator sets the field to the specified value. The $max operator can compare values of different types, using the BSON comparison order.

http://docs.mongodb.org/manual/reference/operator/update/max/